### PR TITLE
Add iOS-specific location instructions and fix test mock for getDb fu…

### DIFF
--- a/__tests__/services/firestore-data-service.test.ts
+++ b/__tests__/services/firestore-data-service.test.ts
@@ -17,6 +17,7 @@ jest.mock('firebase/firestore');
 jest.mock('geofire-common');
 jest.mock('@/lib/firebase/config', () => ({
   db: {},
+  getDb: jest.fn(() => ({})),
 }));
 
 describe('FirestoreDataService', () => {

--- a/app/components/LocationPermission.tsx
+++ b/app/components/LocationPermission.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useI18n } from '@/lib/contexts/I18nContext';
 
 interface LocationPermissionProps {
@@ -11,6 +11,14 @@ export default function LocationPermission({ onRequestPermission }: LocationPerm
   const { t } = useI18n();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const ios = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as Window & { MSStream?: unknown }).MSStream;
+      setIsIOS(ios);
+    }
+  }, []);
 
   const handleRequestPermission = async () => {
     setLoading(true);
@@ -80,9 +88,32 @@ export default function LocationPermission({ onRequestPermission }: LocationPerm
               </svg>
             </div>
             <h2 className="text-2xl font-bold text-gray-900 mb-2">{t.locationPermission.heading}</h2>
-            <p className="text-gray-600">
+            <p className="text-gray-600 mb-4">
               {t.locationPermission.description}
             </p>
+            {isIOS && (
+              <p className="text-gray-600">
+                {t.locationPermission.iosInstructions.split('{locationServicesLink}')[0]}
+                <a
+                  href={t.locationPermission.locationServicesUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:text-blue-800 underline"
+                >
+                  {t.locationPermission.locationServicesText}
+                </a>
+                {t.locationPermission.iosInstructions.split('{locationServicesLink}')[1].split('{homeScreenLink}')[0]}
+                <a
+                  href={t.locationPermission.homeScreenUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:text-blue-800 underline"
+                >
+                  {t.locationPermission.homeScreenText}
+                </a>
+                {t.locationPermission.iosInstructions.split('{homeScreenLink}')[1]}
+              </p>
+            )}
           </div>
 
         {error && (

--- a/lib/i18n/en.json
+++ b/lib/i18n/en.json
@@ -9,6 +9,11 @@
   "locationPermission": {
     "heading": "Location Permission Required",
     "description": "This app needs access to your location to send and receive alerts from nearby users within a 5-mile radius.",
+    "iosInstructions": "On iOS, enable {locationServicesLink} for Safari Websites and save this website as an app to your {homeScreenLink}.",
+    "locationServicesText": "Location Services",
+    "locationServicesUrl": "https://support.apple.com/en-us/102515",
+    "homeScreenText": "Home Screen",
+    "homeScreenUrl": "https://support.apple.com/guide/iphone/open-as-web-app-iphea86e5236/ios",
     "buttonEnable": "Enable Location Access",
     "buttonLoading": "Getting Location...",
     "privacyNotice": {

--- a/lib/i18n/es.json
+++ b/lib/i18n/es.json
@@ -9,6 +9,11 @@
   "locationPermission": {
     "heading": "Se Requiere Permiso de Ubicación",
     "description": "Esta aplicación necesita acceso a tu ubicación para enviar y recibir alertas de usuarios cercanos dentro de un radio de 5 millas.",
+    "iosInstructions": "En iOS, habilita {locationServicesLink} para Sitios Web de Safari y guarda este sitio web como una aplicación en tu {homeScreenLink}.",
+    "locationServicesText": "Servicios de Ubicación",
+    "locationServicesUrl": "https://support.apple.com/es-es/102515",
+    "homeScreenText": "pantalla de inicio",
+    "homeScreenUrl": "https://support.apple.com/es-es/guide/iphone/open-as-web-app-iphea86e5236/ios",
     "buttonEnable": "Habilitar Acceso a Ubicación",
     "buttonLoading": "Obteniendo Ubicación...",
     "privacyNotice": {


### PR DESCRIPTION
…nction

This commit adds helpful iOS-specific instructions on the location permission screen and fixes a test failure in the firestore data service tests.

## Changes:

### Feature: iOS Location Instructions
- Add iOS-specific guidance to location permission screen with links to Apple support
- Display instructions only on iOS devices using user agent detection
- Add bilingual support (English and Spanish) for new instruction text
- Links include:
  - Location Services settings guide
  - Home Screen web app installation guide

### Bug Fix: Test Mock
- Fix firestore-data-service.test.ts to properly mock getDb function
- Test was only mocking db export but code uses getDb() function
- All 93 tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)