### PR TITLE
Responsive header: hide wordmark on small screens, drop redundant onboarding icon

### DIFF
--- a/app/components/LocationPermission.tsx
+++ b/app/components/LocationPermission.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Fragment, useEffect, useRef, useState } from 'react';
-import Image from 'next/image';
 import { useI18n } from '@/lib/contexts/I18nContext';
 import { Apple, Book, Check, Eye, Home, Lock, Pin, Plus, Share, ICON_MAP } from './Icons';
 
@@ -137,7 +136,6 @@ export default function LocationPermission({ onRequestPermission, onOpenGuide }:
         <div className="wrap onb-hero-inner">
           <div className="onb-hero-copy">
             <div className="onb-brandmark">
-              <Image src="/appicon/defroster-512x512.png" alt="Defroster app icon" width={60} height={60} className="onb-brandmark-img" />
               <span className="df-wordmark" style={{ fontSize: '1.5rem' }}>Defroster</span>
             </div>
             <span className="eyebrow">{o.eyebrow}</span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -636,6 +636,7 @@ button { font-family: inherit; }
 }
 @media (max-width: 560px) {
   .df-wordmark { font-size: 1.15rem; }
+  .brand-btn .df-wordmark { display: none; }
   .topnav { gap: 10px; }
   .nav-link { font-size: .92rem; }
   .onb-priv-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary

- **Header (small screens):** Hide the "Defroster" wordmark next to the icon at `≤560px`, leaving only the icon on the left. The rule is scoped to `.brand-btn .df-wordmark` so the footer and onboarding wordmarks (which reuse `.df-wordmark`) are unaffected.
- **Onboarding heading (all screen sizes):** Remove the app-icon image to the left of the "Defroster" heading at the top of the first page's content, since the icon already appears in the header. Removed the now-unused `next/image` import from `LocationPermission.tsx`.

## Changes

- `app/globals.css` — add `.brand-btn .df-wordmark { display: none; }` inside the existing `@media (max-width: 560px)` block.
- `app/components/LocationPermission.tsx` — remove the `<Image>` brandmark from the onboarding hero `.onb-brandmark`, leaving only the wordmark; drop the unused import.

## Notes

Type-checking shows only pre-existing errors in `__tests__/*` (missing test-runner type definitions), unrelated to these changes. No test asserts the removed onboarding icon.

https://claude.ai/code/session_01QUo3d2DvCYoM4nmkQEwony

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUo3d2DvCYoM4nmkQEwony)_