### PR TITLE
Fix map overlapping report button on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -435,7 +435,7 @@ button { font-family: inherit; }
 
 .app-grid { display: grid; grid-template-columns: 1.55fr 1fr; gap: var(--s6); align-items: start; }
 .map-card { padding: 10px; overflow: hidden; }
-.leaflet-host { height: clamp(380px, 56vh, 560px); width: 100%; border-radius: var(--r-md); overflow: hidden; background: var(--paper-2); }
+.leaflet-host { height: clamp(380px, 56vh, 560px); width: 100%; border-radius: var(--r-md); overflow: hidden; background: var(--paper-2); position: relative; z-index: 0; isolation: isolate; }
 .legend { display: flex; flex-wrap: wrap; gap: 8px 18px; margin-top: 14px; padding: 0 6px; }
 .legend-item { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; font-size: calc(var(--t-sm) * var(--text-scale)); color: var(--ink-2); }
 .legend-dot { width: 13px; height: 13px; border-radius: 50% 50% 50% 0; transform: rotate(-45deg); background: var(--sig); border: 2px solid #fff; box-shadow: var(--shadow-xs); }


### PR DESCRIPTION
## Problem

On small screens, the map overlapped and hid the "Report a sighting" button that sits at the bottom of the screen.

## Root cause

The mobile report dock (`.report-dock`) is `position: sticky; bottom: 0; z-index: 30` and floats at the bottom of the viewport, geometrically overlapping the lower portion of the map on small screens.

Leaflet builds its internal panes and controls with `z-index` values up to ~1000. However, `.leaflet-host` only had `overflow: hidden`, which does **not** establish a stacking context. As a result, those high-`z-index` Leaflet elements shared the page's root stacking context and painted *over* the dock (`z-index: 30`), hiding the report button.

## Fix

Give `.leaflet-host` its own stacking context so all of Leaflet's internal z-indexes are contained:

```css
.leaflet-host { ...; position: relative; z-index: 0; isolation: isolate; }
```

- `isolation: isolate` — modern, layout-neutral way to create a stacking context.
- `position: relative; z-index: 0` — broad-compatibility fallback (e.g. older Safari).

With the map's z-indexes contained, the report dock (`z-index: 30`) reliably renders above the map. One-line CSS change, no markup or layout changes.

https://claude.ai/code/session_01QQ6PFG21BS3eJtDcW4pDXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQ6PFG21BS3eJtDcW4pDXc)_