### PR TITLE
Clean up ESLint errors and warnings across tests and config

### DIFF
--- a/__tests__/api/send-message.test.ts
+++ b/__tests__/api/send-message.test.ts
@@ -52,12 +52,10 @@ jest.mock('next/server', () => ({
 }));
 
 import { POST } from '@/app/api/send-message/route';
-import { adminMessaging } from '@/lib/firebase/admin';
-import { NextResponse } from 'next/server';
 import { resetDataService } from '@/lib/services/data-service-singleton';
 
 // Helper to create mock NextRequest
-function createMockRequest(body: any) {
+function createMockRequest(body: Record<string, unknown>) {
   return {
     json: async () => body,
     headers: {
@@ -68,7 +66,7 @@ function createMockRequest(body: any) {
         return null;
       },
     },
-  } as any;
+  } as unknown as Parameters<typeof POST>[0];
 }
 
 describe('POST /api/send-message', () => {
@@ -174,7 +172,7 @@ describe('POST /api/send-message', () => {
       mockGetDevicesInRadius.mockResolvedValue([
         { deviceId: 'device1', token: 'token1', geohash: 'hash1', updatedAt: Date.now() },
         { deviceId: 'device2', token: 'token2', geohash: 'hash2', updatedAt: Date.now() },
-      ] as any);
+      ]);
 
       const request = createMockRequest({
         sightingType: 'Police',

--- a/__tests__/components/SightingMap.test.tsx
+++ b/__tests__/components/SightingMap.test.tsx
@@ -10,10 +10,10 @@ const renderWithI18n = (component: React.ReactElement) => {
 
 // Mock Leaflet and react-leaflet
 jest.mock('react-leaflet', () => ({
-  MapContainer: ({ children }: any) => <div data-testid="map-container">{children}</div>,
+  MapContainer: ({ children }: { children?: React.ReactNode }) => <div data-testid="map-container">{children}</div>,
   TileLayer: () => <div data-testid="tile-layer" />,
-  Marker: ({ children }: any) => <div data-testid="marker">{children}</div>,
-  Popup: ({ children }: any) => <div data-testid="popup">{children}</div>,
+  Marker: ({ children }: { children?: React.ReactNode }) => <div data-testid="marker">{children}</div>,
+  Popup: ({ children }: { children?: React.ReactNode }) => <div data-testid="popup">{children}</div>,
   Circle: () => <div data-testid="circle" />,
   useMap: () => ({
     setView: jest.fn(),

--- a/__tests__/hooks/useGeolocation.test.ts
+++ b/__tests__/hooks/useGeolocation.test.ts
@@ -170,8 +170,8 @@ describe('useGeolocation', () => {
     });
 
     it('should set loading state during request', async () => {
-      let resolvePosition: (pos: any) => void;
-      const positionPromise = new Promise((resolve) => {
+      let resolvePosition: (pos: GeolocationPosition) => void;
+      const positionPromise = new Promise<GeolocationPosition>((resolve) => {
         resolvePosition = resolve;
       });
 
@@ -181,7 +181,7 @@ describe('useGeolocation', () => {
 
       const { result } = renderHook(() => useGeolocation());
 
-      let requestPromise: Promise<any>;
+      let requestPromise: ReturnType<typeof result.current.requestPermission>;
       act(() => {
         requestPromise = result.current.requestPermission();
       });
@@ -195,7 +195,7 @@ describe('useGeolocation', () => {
       await act(async () => {
         resolvePosition!({
           coords: { latitude: 37.7749, longitude: -122.4194 },
-        });
+        } as GeolocationPosition);
         await requestPromise;
       });
 
@@ -250,7 +250,7 @@ describe('useGeolocation', () => {
 
   describe('Edge Cases', () => {
     it('should handle geolocation not supported', async () => {
-      // @ts-ignore
+      // @ts-expect-error Intentionally removing geolocation to test unsupported browsers
       global.navigator.geolocation = undefined;
 
       const { result } = renderHook(() => useGeolocation());
@@ -263,9 +263,7 @@ describe('useGeolocation', () => {
     });
 
     it('should handle multiple concurrent permission requests', async () => {
-      let callCount = 0;
       mockGeolocation.getCurrentPosition.mockImplementation((success) => {
-        callCount++;
         setTimeout(() => {
           success({
             coords: { latitude: 37.7749, longitude: -122.4194 },

--- a/__tests__/hooks/useMessaging.test.ts
+++ b/__tests__/hooks/useMessaging.test.ts
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useMessaging } from '@/app/hooks/useMessaging';
 import { ServicesProvider } from '@/lib/contexts/ServicesContext';
+import { Message } from '@/lib/types/message';
 
 // Mock fetch
 global.fetch = jest.fn();
@@ -40,8 +41,8 @@ describe('useMessaging', () => {
     React.createElement(
       ServicesProvider,
       {
-        messagingService: mockMessagingService as any,
-        storageService: mockStorageService as any,
+        messagingService: mockMessagingService as unknown as React.ComponentProps<typeof ServicesProvider>['messagingService'],
+        storageService: mockStorageService as unknown as React.ComponentProps<typeof ServicesProvider>['storageService'],
       },
       children
     );
@@ -75,7 +76,7 @@ describe('useMessaging', () => {
     global.Notification = {
       permission: 'default',
       requestPermission: jest.fn(() => Promise.resolve('granted')),
-    } as any;
+    } as unknown as typeof Notification;
 
     // Mock navigator.onLine
     Object.defineProperty(global.navigator, 'onLine', {
@@ -476,7 +477,7 @@ describe('useMessaging', () => {
     it('should add new messages to state and save to IndexedDB when received', async () => {
       const { result } = renderHook(() => useMessaging(), { wrapper });
 
-      let messageCallback: any;
+      let messageCallback: (message: Message) => void | Promise<void>;
       mockMessagingService.onMessage.mockImplementation((cb) => {
         messageCallback = cb;
       });
@@ -506,7 +507,7 @@ describe('useMessaging', () => {
     it('should clean up listener on unmount', () => {
       const { result } = renderHook(() => useMessaging(), { wrapper });
 
-      let cleanup: any;
+      let cleanup: ReturnType<typeof result.current.setupMessageListener>;
       act(() => {
         cleanup = result.current.setupMessageListener();
       });
@@ -798,7 +799,7 @@ describe('useMessaging', () => {
     });
 
     it('should handle Notification API not available', async () => {
-      // @ts-ignore
+      // @ts-expect-error Intentionally deleting Notification to test its absence
       delete global.Notification;
 
       const { result } = renderHook(() => useMessaging(), { wrapper });

--- a/__tests__/services/firestore-data-service.test.ts
+++ b/__tests__/services/firestore-data-service.test.ts
@@ -2,7 +2,6 @@ import { FirestoreDataService } from '@/lib/services/firestore-data-service';
 import {
   collection,
   addDoc,
-  query,
   where,
   getDocs,
   deleteDoc,
@@ -24,7 +23,6 @@ describe('FirestoreDataService', () => {
   let service: FirestoreDataService;
   let mockCollection: jest.Mock;
   let mockAddDoc: jest.Mock;
-  let mockQuery: jest.Mock;
   let mockWhere: jest.Mock;
   let mockGetDocs: jest.Mock;
   let mockDeleteDoc: jest.Mock;
@@ -38,7 +36,6 @@ describe('FirestoreDataService', () => {
 
     mockCollection = collection as jest.Mock;
     mockAddDoc = addDoc as jest.Mock;
-    mockQuery = query as jest.Mock;
     mockWhere = where as jest.Mock;
     mockGetDocs = getDocs as jest.Mock;
     mockDeleteDoc = deleteDoc as jest.Mock;

--- a/__tests__/services/indexeddb-storage-service.test.ts
+++ b/__tests__/services/indexeddb-storage-service.test.ts
@@ -1,15 +1,49 @@
 import { IndexedDBStorageService } from '@/lib/services/indexeddb-storage-service';
-import { Message, GeoLocation } from '@/lib/types/message';
+import { Message } from '@/lib/types/message';
 import { AppState } from '@/lib/types/app-state';
 import { ONE_WEEK_MS, ONE_DAY_MS } from '@/lib/constants/time';
 
+// Minimal mock shapes for the subset of the IndexedDB API these tests exercise.
+type MockEventHandler = ((event?: { target?: unknown }) => void) | null;
+
+interface MockIDBRequest {
+  onsuccess: MockEventHandler;
+  onerror: MockEventHandler;
+  onupgradeneeded?: MockEventHandler;
+  result?: unknown;
+  error?: unknown;
+}
+
+interface MockObjectStore {
+  add: jest.Mock;
+  put: jest.Mock;
+  delete: jest.Mock;
+  clear: jest.Mock;
+  openCursor: jest.Mock;
+  getAll: jest.Mock;
+  createIndex: jest.Mock;
+  get?: jest.Mock;
+  index?: jest.Mock;
+}
+
+interface MockTransaction {
+  objectStore: jest.Mock;
+  oncomplete: MockEventHandler;
+  onerror: MockEventHandler;
+}
+
+interface MockDB {
+  transaction: jest.Mock;
+  createObjectStore: jest.Mock;
+  objectStoreNames: { contains: jest.Mock };
+}
+
 describe('IndexedDBStorageService', () => {
   let service: IndexedDBStorageService;
-  let mockDB: any;
-  let mockObjectStore: any;
-  let mockTransaction: any;
-  let mockRequest: any;
-  let mockCursor: any;
+  let mockDB: MockDB;
+  let mockObjectStore: MockObjectStore;
+  let mockTransaction: MockTransaction;
+  let mockRequest: MockIDBRequest;
 
   beforeEach(() => {
     service = new IndexedDBStorageService();
@@ -49,16 +83,10 @@ describe('IndexedDBStorageService', () => {
       result: mockDB,
     };
 
-    // Mock cursor
-    mockCursor = {
-      value: null,
-      continue: jest.fn(),
-    };
-
     // Mock indexedDB
     global.indexedDB = {
       open: jest.fn(() => mockRequest),
-    } as any;
+    } as unknown as IDBFactory;
   });
 
   afterEach(() => {
@@ -72,7 +100,7 @@ describe('IndexedDBStorageService', () => {
       // Simulate successful database opening
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
 
@@ -86,10 +114,10 @@ describe('IndexedDBStorageService', () => {
       // Simulate database upgrade
       setTimeout(() => {
         if (mockRequest.onupgradeneeded) {
-          mockRequest.onupgradeneeded({ target: mockRequest } as any);
+          mockRequest.onupgradeneeded({ target: mockRequest });
         }
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
 
@@ -131,7 +159,7 @@ describe('IndexedDBStorageService', () => {
       const initPromise = service.initialize();
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
       await initPromise;
@@ -145,7 +173,7 @@ describe('IndexedDBStorageService', () => {
 
       setTimeout(() => {
         if (putRequest.onsuccess) {
-          putRequest.onsuccess({} as any);
+          putRequest.onsuccess({});
         }
       }, 0);
 
@@ -195,7 +223,7 @@ describe('IndexedDBStorageService', () => {
       const initPromise = service.initialize();
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
       await initPromise;
@@ -210,11 +238,11 @@ describe('IndexedDBStorageService', () => {
       // Simulate each put operation succeeding
       setTimeout(() => {
         if (putRequest.onsuccess) {
-          putRequest.onsuccess({} as any);
-          putRequest.onsuccess({} as any);
+          putRequest.onsuccess({});
+          putRequest.onsuccess({});
         }
         if (mockTransaction.oncomplete) {
-          mockTransaction.oncomplete({} as any);
+          mockTransaction.oncomplete({});
         }
       }, 0);
 
@@ -228,7 +256,7 @@ describe('IndexedDBStorageService', () => {
       const initPromise = service.initialize();
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
       await initPromise;
@@ -253,7 +281,7 @@ describe('IndexedDBStorageService', () => {
 
       setTimeout(() => {
         if (getAllRequest.onsuccess) {
-          getAllRequest.onsuccess({ target: getAllRequest } as any);
+          getAllRequest.onsuccess({ target: getAllRequest });
         }
       }, 0);
 
@@ -267,7 +295,7 @@ describe('IndexedDBStorageService', () => {
       const initPromise = service.initialize();
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
       await initPromise;
@@ -317,7 +345,7 @@ describe('IndexedDBStorageService', () => {
               value: expiredMessages[callCount],
               delete: jest.fn(() => {
                 if (deleteRequest.onsuccess) {
-                  deleteRequest.onsuccess({} as any);
+                  deleteRequest.onsuccess({});
                 }
               }),
               continue: jest.fn(() => {
@@ -326,12 +354,12 @@ describe('IndexedDBStorageService', () => {
               }),
             };
             if (cursorRequest.onsuccess) {
-              cursorRequest.onsuccess({ target: cursorRequest } as any);
+              cursorRequest.onsuccess({ target: cursorRequest });
             }
           } else {
             cursorRequest.result = null;
             if (cursorRequest.onsuccess) {
-              cursorRequest.onsuccess({ target: cursorRequest } as any);
+              cursorRequest.onsuccess({ target: cursorRequest });
             }
           }
         };
@@ -348,7 +376,7 @@ describe('IndexedDBStorageService', () => {
       const initPromise = service.initialize();
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
       await initPromise;
@@ -362,7 +390,7 @@ describe('IndexedDBStorageService', () => {
 
       setTimeout(() => {
         if (clearRequest.onsuccess) {
-          clearRequest.onsuccess({} as any);
+          clearRequest.onsuccess({});
         }
       }, 0);
 
@@ -377,7 +405,7 @@ describe('IndexedDBStorageService', () => {
       const initPromise = service.initialize();
       setTimeout(() => {
         if (mockRequest.onsuccess) {
-          mockRequest.onsuccess({ target: mockRequest } as any);
+          mockRequest.onsuccess({ target: mockRequest });
         }
       }, 0);
       await initPromise;
@@ -402,7 +430,7 @@ describe('IndexedDBStorageService', () => {
 
         setTimeout(() => {
           if (putRequest.onsuccess) {
-            putRequest.onsuccess({} as any);
+            putRequest.onsuccess({});
           }
         }, 0);
 
@@ -428,7 +456,7 @@ describe('IndexedDBStorageService', () => {
 
         setTimeout(() => {
           if (putRequest.onerror) {
-            putRequest.onerror({} as any);
+            putRequest.onerror({});
           }
         }, 0);
 
@@ -447,13 +475,13 @@ describe('IndexedDBStorageService', () => {
 
         setTimeout(() => {
           if (openRequest.onsuccess) {
-            openRequest.onsuccess({ target: openRequest } as any);
+            openRequest.onsuccess({ target: openRequest });
           }
         }, 0);
 
         setTimeout(() => {
           if (putRequest.onsuccess) {
-            putRequest.onsuccess({} as any);
+            putRequest.onsuccess({});
           }
         }, 10);
 
@@ -486,7 +514,7 @@ describe('IndexedDBStorageService', () => {
         setTimeout(() => {
           getRequest.result = savedState;
           if (getRequest.onsuccess) {
-            getRequest.onsuccess({ target: getRequest } as any);
+            getRequest.onsuccess({ target: getRequest });
           }
         }, 0);
 
@@ -504,7 +532,7 @@ describe('IndexedDBStorageService', () => {
         setTimeout(() => {
           getRequest.result = null;
           if (getRequest.onsuccess) {
-            getRequest.onsuccess({ target: getRequest } as any);
+            getRequest.onsuccess({ target: getRequest });
           }
         }, 0);
 
@@ -532,7 +560,7 @@ describe('IndexedDBStorageService', () => {
         setTimeout(() => {
           getRequest.result = staleState;
           if (getRequest.onsuccess) {
-            getRequest.onsuccess({ target: getRequest } as any);
+            getRequest.onsuccess({ target: getRequest });
           }
         }, 0);
 
@@ -548,7 +576,7 @@ describe('IndexedDBStorageService', () => {
 
         setTimeout(() => {
           if (getRequest.onerror) {
-            getRequest.onerror({ target: { error: new Error('Get failed') } } as any);
+            getRequest.onerror({ target: { error: new Error('Get failed') } });
           }
         }, 0);
 
@@ -566,7 +594,7 @@ describe('IndexedDBStorageService', () => {
 
         setTimeout(() => {
           if (deleteRequest.onsuccess) {
-            deleteRequest.onsuccess({} as any);
+            deleteRequest.onsuccess({});
           }
         }, 0);
 
@@ -582,7 +610,7 @@ describe('IndexedDBStorageService', () => {
 
         setTimeout(() => {
           if (deleteRequest.onerror) {
-            deleteRequest.onerror({} as any);
+            deleteRequest.onerror({});
           }
         }, 0);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,12 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      // Firebase Cloud Functions is a separate package with its own
+      // package.json, tsconfig and lint setup; it is linted independently.
+      "functions/**",
+      // Node CommonJS build scripts and config that legitimately use require().
+      "scripts/**",
+      "jest.config.js",
     ],
   },
 ];


### PR DESCRIPTION
## Summary

`npm run lint` surfaced **53 errors + 10 warnings**, all pre-existing. The Next.js app code (`app/`, `lib/`, `components/`) was already clean — the issues were confined to test files, the separate Cloud Functions package, and Node build scripts. This PR gets `npm run lint` to pass cleanly while leaving runtime behavior untouched.

## Changes

**ESLint config scoping** (`eslint.config.mjs`)
- Ignore `functions/**` — it's a **separate package** with its own `package.json`, `package-lock.json`, `tsconfig.json` and lint setup; it should be linted independently, not by the root Next config.
- Ignore `scripts/**` and `jest.config.js` — Node CommonJS build scripts/config that legitimately use `require()`.

**Test files** — genuinely fixed (no rule suppression):
- Replaced `any` with precise types: typed mock component props, `GeolocationPosition`, `Message`, `ReturnType<…>`/`React.ComponentProps<…>`-derived types, and minimal `IndexedDB` mock interfaces (`MockIDBRequest`, `MockObjectStore`, etc.).
- Dropped now-unnecessary `as any` casts on mock event-handler invocations.
- Swapped `@ts-ignore` → `@ts-expect-error`.
- Removed unused imports/variables (`adminMessaging`, `NextResponse`, `GeoLocation`, `mockQuery`, `mockCursor`, `callCount`).

## Verification
- `npm run lint` → clean (0 errors, 0 warnings).
- `npm test` → **130/130 passing**.
- `npm run build` → succeeds; lint/type-check step passes.

## Note on build warnings (not addressed — not code defects)
- `metadataBase … not set`: only appears when building locally without `NEXT_PUBLIC_BASE_URL`. It's already env-driven and set in production; hardcoding a URL would break preview-vs-prod resolution.
- `Critical dependency` from `protobufjs`: originates in the upstream Firebase/gRPC dependency chain, not fixable in our code.

https://claude.ai/code/session_01QQ6PFG21BS3eJtDcW4pDXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQ6PFG21BS3eJtDcW4pDXc)_