### PR TITLE
Align Know Your Rights breadcrumb baselines

### DIFF
--- a/app/components/ImmigrationGuide.tsx
+++ b/app/components/ImmigrationGuide.tsx
@@ -62,10 +62,12 @@ export default function ImmigrationGuide({ onBack }: ImmigrationGuideProps) {
       {/* Header */}
       <header className="g-hero">
         <div className="wrap read">
-          {onBack && (
-            <button className="back-btn" onClick={onBack}><ArrowLeft size={20} /> {t.nav.app}</button>
-          )}
-          <span className="eyebrow" style={{ color: 'var(--ember-600)' }}>Defroster · {t.nav.guide}</span>
+          <div className="g-breadcrumb">
+            {onBack && (
+              <button className="back-btn" onClick={onBack}><ArrowLeft size={20} /> {t.nav.app}</button>
+            )}
+            <span className="eyebrow" style={{ color: 'var(--ember-600)' }}>Defroster · {t.nav.guide}</span>
+          </div>
           <h1 className="g-title">{g.title}</h1>
           <p className="g-sub">{g.sub}</p>
           <a className="g-rights-link" href={g.rightsUrl} target="_blank" rel="noopener noreferrer">

--- a/app/globals.css
+++ b/app/globals.css
@@ -517,7 +517,8 @@ button { font-family: inherit; }
 .guide { padding-bottom: var(--s10); }
 .g-hero { padding: clamp(28px, 4vw, 52px) 0 var(--s6); background: linear-gradient(180deg, var(--accent-tint), transparent); }
 .g-breadcrumb { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
-.back-btn { display: inline-flex; align-items: center; gap: 6px; background: none; border: none; cursor: pointer; font-family: var(--font-sans); font-weight: 700; color: var(--accent-600); padding: 8px 6px 8px 0; }
+.back-btn { display: inline-flex; align-items: baseline; gap: 6px; background: none; border: none; cursor: pointer; font-family: var(--font-sans); font-weight: 700; color: var(--accent-600); padding: 8px 6px 8px 0; }
+.back-btn svg { align-self: center; }
 .back-btn:hover { text-decoration: underline; }
 .g-title { font-size: var(--t-h1); font-weight: 800; letter-spacing: -0.025em; margin: 8px 0 14px; }
 .g-sub { color: var(--ink-2); font-size: calc(var(--t-lg) * var(--text-scale)); line-height: 1.5; max-width: 36em; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -516,7 +516,8 @@ button { font-family: inherit; }
    ============================================================ */
 .guide { padding-bottom: var(--s10); }
 .g-hero { padding: clamp(28px, 4vw, 52px) 0 var(--s6); background: linear-gradient(180deg, var(--accent-tint), transparent); }
-.back-btn { display: inline-flex; align-items: center; gap: 6px; background: none; border: none; cursor: pointer; font-family: var(--font-sans); font-weight: 700; color: var(--accent-600); padding: 8px 6px 8px 0; margin-bottom: 12px; }
+.g-breadcrumb { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.back-btn { display: inline-flex; align-items: center; gap: 6px; background: none; border: none; cursor: pointer; font-family: var(--font-sans); font-weight: 700; color: var(--accent-600); padding: 8px 6px 8px 0; }
 .back-btn:hover { text-decoration: underline; }
 .g-title { font-size: var(--t-h1); font-weight: 800; letter-spacing: -0.025em; margin: 8px 0 14px; }
 .g-sub { color: var(--ink-2); font-size: calc(var(--t-lg) * var(--text-scale)); line-height: 1.5; max-width: 36em; }


### PR DESCRIPTION
## Summary

In the **Know Your Rights** view, the two breadcrumbs at the top of the page — the **Alerts** back button and the **DEFROSTER · KNOW YOUR RIGHTS** eyebrow — sat on the same row via inline flow, but their text baselines didn't line up. The back button is an `inline-flex` containing a 20px arrow icon, so its baseline was synthesized from the icon rather than the label text, leaving the eyebrow text visually misaligned.

## Change

- Wrapped both breadcrumbs in a new `.g-breadcrumb` flex container with `align-items: baseline`, so the two text baselines align. This mirrors the existing `.g-toc` row, which already uses the same `display: flex; align-items: baseline` pattern.
- Moved the `margin-bottom: 12px` spacing from `.back-btn` onto the `.g-breadcrumb` wrapper so vertical spacing below the breadcrumbs is preserved whether or not the back button is present.

## Files

- `app/components/ImmigrationGuide.tsx` — wrap the back button + eyebrow in `.g-breadcrumb`
- `app/globals.css` — add `.g-breadcrumb`; drop the now-redundant `margin-bottom` on `.back-btn`

## Notes

Dependencies are not installed in this environment, so lint/build could not be run here. The change is a structural JSX wrapper plus CSS only.

https://claude.ai/code/session_014J5NVv7M2gXAeiUPhYERA1

---
_Generated by [Claude Code](https://claude.ai/code/session_014J5NVv7M2gXAeiUPhYERA1)_